### PR TITLE
PKI-26399 Use subject_variables for the signing and issuing end point…

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,22 +62,25 @@ You can configure the CA Gateway plugin by writing to the `/config` endpoint. Th
 
 ### Profile Configuration
 
-* **common_name_variable** - The name of the subject variable to used to supply the common name to the gateway. The default is 'cn'.
 * **ttl** - The lease duration if no specific lease duration is requested. The lease duration controls the expiration of certificates issued by this backend. Defaults to the value of max_ttl.  Value is in seconds.
 * **max_ttl** - The maximum allowed lease duration. Value is in seconds.
 
 #### Example
 
->`vault write pki/config/profiles/PROF-101 common_name=cn ttl=15552000 max_ttl=31104000`
+>`vault write pki/config/profiles/PROF-101 ttl=15552000 max_ttl=31104000`
+
+The profile write operation will connect to CAGW to get the profile properties. The profile properties include the subject variable requirements and subject alternative name requirements if available. These requirements must be provided for the sign or issue operations. The read operation will display these properties.
 
 >`vault read pki/config/profiles/PROF-101`
 
 ## Usage
 
-To issue a new certificate, write a CSR and common name to the sign endpoint with the profile identifier at the end of the path.
+* **subject_variables** - A comma separated list of the subject variable types and values to use. The types should match with the profile configuration.
 
->`vault write pki/sign/CA-PROF-1001 csr=@csr.pem common_name=example.com`
+To issue a new certificate, write a CSR and subject variables to the sign endpoint with the profile identifier at the end of the path.
 
-To issue a new PKCS12 (generate the private key with the certificate), write a common name to the issue endpoint with the profile identifier at the end of the path.
+>`vault write pki/sign/CA-PROF-1001 csr=@csr.pem subject_variables=cn=example.com,o=Entrust,c=CA`
 
->`vault write pki/issue/CA-PROF-1002 common_name=example.com`
+To issue a new PKCS12 (generate the private key with the certificate), write subject variables to the issue endpoint with the profile identifier at the end of the path.
+
+>`vault write pki/issue/CA-PROF-1002 subject_variables=cn=example.com,o=Entrust,c=CA`

--- a/cagw_config_profile_entry.go
+++ b/cagw_config_profile_entry.go
@@ -5,14 +5,103 @@
 
 package main
 
-import "time"
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
 
-type CAGWConfigProfileEntry struct {
-	/*
-		The name of the subject variable to use for the common_name. By
-		default this is a variable named 'cn'.
-	*/
-	CommonNameVariable string        `json:"common_name_variable" mapstructure:"common_name_variable"`
-	TTL                time.Duration `json:"ttl_duration" mapstructure:"ttl_duration"`
-	MaxTTL             time.Duration `json:"max_ttl_duration" mapstructure:"max_ttl_duration"`
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+	"github.com/pkg/errors"
+)
+
+type CAGWProfileEntry struct {
+	Id                          string                       `json:"id"`
+	Name                        string                       `json:"name"`
+	SubjectVariableRequirements []SubjectVariableRequirement `json:"subjectVariableRequirements"`
+	SubjectAltNameRequirements  []SubjectAltNameRequirement  `json:"subjectAltNameRequirements"`
+	TTL                         time.Duration                `json:"ttl_duration" mapstructure:"ttl_duration"`
+	MaxTTL                      time.Duration                `json:"max_ttl_duration" mapstructure:"max_ttl_duration"`
+}
+
+type CAGWProfileID struct {
+	Id string
+}
+
+func (p CAGWProfileID) Entry(ctx context.Context, req *logical.Request, data *framework.FieldData) (*CAGWProfileEntry, error) {
+
+	if len(p.Id) == 0 {
+		return nil, errors.New("Missing the profile ID")
+	}
+
+	configEntry, err := getConfigEntry(ctx, req)
+	if err != nil {
+		return nil, errors.New("Error fetching config")
+	}
+
+	tlsClientConfig, err := getTLSConfig(ctx, req, configEntry)
+	if err != nil {
+		return nil, fmt.Errorf("Error retrieving TLS configuration: %g", err)
+	}
+
+	profileResp, err := getResponse(tlsClientConfig, configEntry, p.Id)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error response received from gateway: %g", err)
+	}
+
+	ttl := time.Duration(data.Get("ttl").(int)) * time.Second
+	maxTtl := time.Duration(data.Get("max_ttl").(int)) * time.Second
+
+	entry := &CAGWProfileEntry{
+		profileResp.Profile.Id,
+		profileResp.Profile.Name,
+		profileResp.Profile.SubjectVariableRequirements,
+		profileResp.Profile.SubjectAltNameRequirements,
+		ttl,
+		maxTtl,
+	}
+
+	return entry, nil
+
+}
+
+func getResponse(tlsClientConfig *tls.Config, configEntry *CAGWConfigEntry, profileID string) (*ProfileResponse, error) {
+	tr := &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: tlsClientConfig,
+	}
+
+	client := &http.Client{Transport: tr}
+
+	resp, err := client.Get(configEntry.URL + "/v1/certificate-authorities/" + configEntry.CaId + "/profiles/" + profileID)
+	if err != nil {
+		return nil, fmt.Errorf("Error response: %g", err)
+	}
+
+	responseBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("CAGW response could not be read: %g", err)
+	}
+
+	if resp.StatusCode != 200 {
+		var errorResponse *ErrorResponse
+		err := json.Unmarshal(responseBody, &errorResponse)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("CAGW error response could not be parsed (%d)", resp.StatusCode))
+		}
+		return nil, errors.New(fmt.Sprintf("Error from gateway: %s (%d)", errorResponse.Error.Message, resp.StatusCode))
+	}
+
+	var profileResp *ProfileResponse
+	err = json.Unmarshal(responseBody, &profileResp)
+	if err != nil {
+		return nil, fmt.Errorf("CAGW enrollment response could not be parsed: %g", err)
+	}
+
+	return profileResp, nil
 }

--- a/config.go
+++ b/config.go
@@ -7,9 +7,9 @@ package main
 
 import (
 	"context"
+
 	"github.com/hashicorp/vault/logical"
 	"github.com/pkg/errors"
-	"time"
 )
 
 func getConfigEntry(ctx context.Context, req *logical.Request) (*CAGWConfigEntry, error) {
@@ -29,14 +29,14 @@ func getConfigEntry(ctx context.Context, req *logical.Request) (*CAGWConfigEntry
 	return &configEntry, nil
 }
 
-func getProfileConfig(ctx context.Context, req *logical.Request, profileName string) (*CAGWConfigProfileEntry, error) {
+func getProfileConfig(ctx context.Context, req *logical.Request, profileName string) (*CAGWProfileEntry, error) {
 	profileStorageEntry, err := req.Storage.Get(ctx, "config/profile/"+profileName)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "CAGW profile configuration could not be loaded")
 	}
 
-	configProfileEntry := CAGWConfigProfileEntry{}
+	configProfileEntry := CAGWProfileEntry{}
 
 	// If there is a storage entry, decode it, else use defaults
 	if profileStorageEntry != nil {
@@ -45,9 +45,7 @@ func getProfileConfig(ctx context.Context, req *logical.Request, profileName str
 			return nil, errors.Wrap(err, "CAGW profile configuration could not be parsed")
 		}
 	} else {
-		configProfileEntry.CommonNameVariable = "cn"
-		configProfileEntry.TTL, _ = time.ParseDuration("2160h") // 90 days
-		configProfileEntry.MaxTTL = 0
+		return nil, errors.Wrap(err, "CAGW profile configuration could not be found")
 	}
 
 	return &configProfileEntry, nil

--- a/fields_common.go
+++ b/fields_common.go
@@ -25,14 +25,11 @@ key and issuing cert will be appended to the
 certificate pem. Defaults to "pem".`,
 	}
 
-	fields["common_name"] = &framework.FieldSchema{
+	fields["subject_variables"] = &framework.FieldSchema{
 		Type: framework.TypeString,
-		Description: `The requested common name; this name will be
-used as the subject variable value for the 
-subject variable type specified in the 
-common_name_variable in the  profile's 
-configuration or "cn" if no profile config
-exists.`,
+		Description: `The requested subject variables; this is a comma separated list
+of subject variable types and values. The types should match the profile's
+configuration.`,
 	}
 
 	fields["alt_names"] = &framework.FieldSchema{

--- a/op_config.go
+++ b/op_config.go
@@ -68,9 +68,9 @@ func (b *backend) opReadConfig(ctx context.Context, req *logical.Request, data *
 	}
 
 	var rawData map[string]interface{}
-	error := storageEntry.DecodeJSON(&rawData)
+	err = storageEntry.DecodeJSON(&rawData)
 
-	if error != nil {
+	if err != nil {
 		return logical.ErrorResponse("json decoding failed"), err
 	}
 

--- a/path_config_profile.go
+++ b/path_config_profile.go
@@ -29,13 +29,6 @@ func pathConfigProfile(b *backend) *framework.Path {
 		},
 	}
 
-	ret.Fields["common_name_variable"] = &framework.FieldSchema{
-		Type:    framework.TypeString,
-		Default: "cn",
-		Description: "The name of the subject variable to used to supply the common " +
-			"name to the gateway.",
-	}
-
 	ret.Fields["ttl"] = &framework.FieldSchema{
 		Type: framework.TypeDurationSecond,
 		Description: "The lease duration if no specific lease duration is requested. " +

--- a/profile_response.go
+++ b/profile_response.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020 Entrust Datacard Corporation.
+ * All rights reserved.
+ */
+
+package main
+
+type ProfileResponse struct {
+	Profile Profile `json:"profile"`
+	Message Message `json:"message"`
+}
+
+type Profile struct {
+	Id                          string                       `json:"id"`
+	Name                        string                       `json:"name"`
+	SubjectVariableRequirements []SubjectVariableRequirement `json:"subjectVariableRequirements"`
+	SubjectAltNameRequirements  []SubjectAltNameRequirement  `json:"subjectAltNameRequirements"`
+}
+
+type SubjectVariableRequirement struct {
+	Name     string `json:"name"`
+	Required bool   `json:"required"`
+}
+
+type SubjectAltNameRequirement struct {
+	Type     string `json:"type"`
+	Required bool   `json:"required"`
+}

--- a/subjects_common.go
+++ b/subjects_common.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020 Entrust Datacard Corporation.
+ * All rights reserved.
+ */
+
+package main
+
+import (
+	"log"
+	"strings"
+)
+
+func processSubjectVariables(subjectVar string) []SubjectVariable {
+	vars := strings.Split(subjectVar, ",")
+
+	var subjectVariables []SubjectVariable
+	for _, v := range vars {
+		typeValue := strings.SplitN(v, "=", 2)
+		if len(typeValue) != 2 {
+			log.Printf("Invalid subject variable: %s. Subject variables must use = to separate type from value.", v)
+			continue
+		}
+		subjectVariables = append(subjectVariables, SubjectVariable{typeValue[0], typeValue[1]})
+	}
+
+	return subjectVariables
+}


### PR DESCRIPTION
…s. Remove common_name config from the profile. Instead retrieve the subject variable requirements from the CAGW profile endpoint and store it for the read operation or any later validation