### PR TITLE
ATEAM-7039: RFE- USBank - HashiCorp Vault plugin for CAGW must be com…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,19 @@ Entrust CA Gateway Vault plugin allows you to issue certificates from an externa
 
 ## Details
 
-The Entrust CA Gateway Vault plugin allows Vault to issue certificates that come through the CA Gateway from the underlying external Certificate Authority. Vault comes with a built-in CA as part of its Secrets Engine, but using that internal CA will often not meet regulatory or company security requirements. If this is the case, then you have two options:
+The Entrust CA Gateway Vault plugin allows Vault to issue certificates that come through the CA Gateway from the 
+underlying external Certificate Authority. Vault comes with a built-in CA as part of its Secrets Engine, but using 
+that internal CA will often not meet regulatory or company security requirements. If this is the case, then you have 
+two options:
 * Use the Vault provisions to root to an external CA rather than self-sign its own CA certificate,
 * Or, plug into your own issuing CA.
 
-Doing the latter has the advantage that the certificates you create will be visible in the Entrust management console and subject to the policies and controls set up by your organization. This CA may be either one that you self-manage and host in your own private/public cloud or one that is managed and hosted by Entrust.
+Doing the latter has the advantage that the certificates you create will be visible in the Entrust management console 
+and subject to the policies and controls set up by your organization. This CA may be either one that you self-manage 
+and host in your own private/public cloud or one that is managed and hosted by Entrust.
 
-This plugin is designed to be a drop in replacement for Vault's built in PKI plugin, implementing the capability necessary to support the certificate issuance.
+This plugin is designed to be a drop in replacement for Vault's built in PKI plugin, implementing the capability 
+necessary to support the certificate issuance.
 
 
 ## Build
@@ -47,69 +53,138 @@ More information about Vault plugins can be found here: https://vaultproject.io/
 
 ## Configuration
 
-### Base Configuration
+### CAGW Role Configuration
 
-You can configure the CA Gateway plugin by writing to the `/config/{caId}` endpoint where {caId} is the CA Gateway identifier of the managed CA. The configuration accepts three properties:
+The CAGW plugin is configured by defining role configurations. Each role configuration contains the credentials and url
+for a specific CAGW. The role configuration also contains a CA identifier for the CA to associate the role
+configuration to and a profile identifier to associate the role configuration with a profile for that CA.
+
+You can configure the CA Gateway plugin by writing to the `/config/{roleName}` endpoint. The configuration accepts 
+these properties:
 * **pem_bundle** - The certificate and key to login to the CA Gateway with in PEM format.
 * **url** - The URL for the CA Gateway server including the context path.
 * **cacerts** - The complete certificate chain for the CA in PEM format.
+* **ca_id** - The CA identifier
+* **profile_id** - The profile identifier
 
-#### Example
->`vault write cagw/config/CA_1001 pem_bundle=@user.pem url=https://cagateway:8080/cagw cacerts=@cagw.root.pem`
+If a **ca_id** is not provided during configuration, the role configuration's name is used as the CA identifier.
 
-The above write operation will connect to CAGW to get the profile IDs for the managed CA. The read operation will display these profile IDs which are required for the profile configuration.
+If a **profile_id** is not provided during configuration, the role configuration is associated with all profiles for
+the corresponding CA. In this case a profile identifier must be provided during all operations with that role
+configuration.
 
->`vault read cagw/config/CA_1001`
+#### Examples
 
->`vault read -field=CACerts cagw/config/CA_1001`
+##### Configure a Role With a CA and Profile
 
->`vault read -field=URL cagw/config/CA_1001`
+>`vault write cagw/config/CA01_profile01_role ca_id=CA01 profile_id=profile01 pem_bundle=@user.pem
+> url=https://cagateway:8080/cagw cacerts=@cagw.root.pem`
 
->`vault read -field=CaId cagw/config`
+The write operation will connect to CAGW to get the profile IDs for the managed CA.
+
+##### Configure a Role With a CA and All Profiles (legacy)
+
+>`vault write cagw/config/CA01_role ca_id=CA01 pem_bundle=@user.pem url=https://cagateway:8080/cagw
+> cacerts=@cagw.root.pem`
+
+##### Configure a Role With a Default CA ID (legacy)
+
+>`vault write cagw/config/CA01 pem_bundle=@user.pem url=https://cagateway:8080/cagw cacerts=@cagw.root.pem`
+
+##### Read a Role Configuration
+
+The below read operation will display the role configuration 
+
+>`vault read cagw/config/CA01_profile01_role`
+
+The three operations below will display individual fields of the role configuration.
+
+>`vault read -field=CACerts cagw/config/CA01_profile01_role`
+
+>`vault read -field=CAId cagw/config/CA01_profile01_role`
+
+>`vault read -field=URL cagw/config/CA01_profile01_role`
+
+The below read operation will display the profile IDs which are available for the role configuration. If the role
+configuration has a profile specified this command will only show that profile. If the role configuration is not
+associated with a profile all the available profiles for that CA will be listed.
+
+>`vault read -field=Profiles cagw/config/CA01_profile01_role`
 
 ### Profile Configuration
 
-* **ttl** - The lease duration if no specific lease duration is requested. The lease duration controls the expiration of certificates issued by this backend. Defaults to the value of max_ttl.  Value is in seconds.
+A configuration for each profile to be used with a role configuration must be created before any actions can be
+performed with that role configuration and profile.
+
+You can configure a role configuration's profile by writing to the `/config/{roleName}/profile` endpoint. The profile 
+write operation will connect to CAGW to get additional profile properties. The configuration accepts these properties:
+* **ttl** - The lease duration if no specific lease duration is requested. The lease duration controls the expiration 
+  of certificates issued by this backend. Defaults to the value of max_ttl.  Value is in seconds.
 * **max_ttl** - The maximum allowed lease duration. Value is in seconds.
 
-#### Example
+#### Examples
 
->`vault write cagw/config/CA_1001/profiles/PROF-101 ttl=15552000 max_ttl=31104000`
+##### Configure Profile
 
-The profile write operation will connect to CAGW to get the profile properties. The profile properties include the subject variable requirements and subject alternative name requirements if available. These requirements must be provided for the sign or issue operations. The read operation will display these properties.
+This command will configure a role configuration's profile.
 
->`vault read cagw/config/CA_1001/profiles/PROF-101`
+>`vault write cagw/config/CA01_profile01_role/profile ttl=15552000 max_ttl=31104000`
+
+##### Configure Profile For Role With Multiple Profiles (legacy)
+
+This type of command must be used for role configurations not associated to a single profile.
+
+>`vault write cagw/config/CA01/profiles/profile01 ttl=15552000 max_ttl=31104000`
+
+##### Read Profile Configuration
+
+The following command reads a profile configuration for the specified role configuration.
+
+>`vault read cagw/config/CA01_profile01_role/profile`
+
+The profile properties include the subject variable requirements and subject alternative name requirements if
+available. These requirements must be provided for the sign or issue operations. The read operation will display
+these properties.
 
 ## Usage
 
-* **subject_variables** - A comma separated list of the subject variable types and values to use. The types should match with the profile configuration.
+The issue and sign endpoints accept the following parameters.
 
-* **alt_names** - A comma-separated list of the subject alternative names (SAN). Each SAN must have the type and value separated by the equal sign.
+* **subject_variables** - A comma separated list of the subject variable types and values to use. The types should 
+  match with the profile configuration.
+
+* **alt_names** - A comma-separated list of the subject alternative names (SAN). Each SAN must have the type and value 
+  separated by the equal sign.
+  
+* **ttl** - The lease duration to request. The value is in seconds. 
 
 To issue a new certificate, write a CSR to the sign endpoint with the managed CA identifier at the end of the path.
 
->`vault write cagw/sign/CA_1001 profile=CA-PROF-1001 csr=@csr.pem subject_variables=cn=example.com,o=Entrust,c=CA`
+>`vault write cagw/sign/CA01_profile01_role csr=@csr.pem subject_variables=cn=example.com,o=Entrust,c=CA`
 
-To issue a new PKCS12 (generate the private key with the certificate), write to the issue endpoint with the managed CA identifier at the end of the path.
+To issue a new PKCS12 (generate the private key with the certificate), write to the issue endpoint with the managed CA 
+identifier at the end of the path.
 
->`vault write cagw/issue/CA_1001 profile=CA-PROF-1002 subject_variables=cn=example.com,o=Entrust,c=CA`
+>`vault write cagw/issue/CA01_profile01_role subject_variables=cn=example.com,o=Entrust,c=CA`
 
 Subject variables can be template variables as defined in the profile.
 
->`vault write cagw/issue/CA_1001 profile=CA-PROF-1002 subject_variables="firstname=Atul,lastname=Gawande"`
+>`vault write cagw/issue/CA01_profile01_role subject_variables="firstname=Atul,lastname=Gawande"`
 
 To include SAN in the request, use the alt_names option.
 
->`vault write cagw/issue/CA_1001 profile=CA-PROF-1002 subject_variables="firstname=Tim,lastname=Marshal" alt_names="dNSName=www.entrust.com,iPAddress=10.10.10.10,rfc822Name=tim@enttrust.com"`
+>`vault write cagw/issue/CA01_profile01_role subject_variables="firstname=Tim,lastname=Marshal" 
+> alt_names="dNSName=www.entrust.com,iPAddress=10.10.10.10,rfc822Name=tim@entrust.com"`
 
-The list opereation will return the serial numbers of all the certificates in the secrets engine for the specific CA. The read operation with the required serial value will return the certificate and its private key if available.
+The list operation will return the serial numbers of all the certificates in the secrets engine for the specific CA. 
+The read operation with the required serial value will return the certificate and its private key if available.
 
->`vault list cagw/issue/CA_1001`
+>`vault list cagw/issue/CA01_profile01_role`
 
->`vault read cagw/issue/CA_1001 serial=1488848948`
+>`vault read cagw/issue/CA01_profile01_role serial=1488848948`
 
->`vault read -field=private_key cagw/issue/CA_1001 serial=1488848948`
+>`vault read -field=private_key cagw/issue/CA01_profile01_role serial=1488848948`
 
->`vault read -field=certificate cagw/issue/CA_1001 serial=1488848948` 
+>`vault read -field=certificate cagw/issue/CA01_profile01_role serial=1488848948` 
 
->`vault read -field=chain cagw/issue/CA_1001 serial=1488848948`
+>`vault read -field=chain cagw/issue/CA01_profile01_role serial=1488848948`

--- a/certs.go
+++ b/certs.go
@@ -14,9 +14,9 @@ import (
 
 func opListCerts(ctx context.Context, req *logical.Request, data *framework.FieldData, path string) (response *logical.Response, retErr error) {
 
-	caId := data.Get("caId").(string)
+	roleName := data.Get("roleName").(string)
 
-	entries, err := req.Storage.List(ctx, path+"/"+caId+"/")
+	entries, err := req.Storage.List(ctx, path+"/"+roleName+"/")
 	if err != nil {
 		return nil, err
 	}
@@ -26,10 +26,10 @@ func opListCerts(ctx context.Context, req *logical.Request, data *framework.Fiel
 
 func opReadCert(ctx context.Context, req *logical.Request, data *framework.FieldData, path string) (*logical.Response, error) {
 
-	caId := data.Get("caId").(string)
+	roleName := data.Get("roleName").(string)
 	serial := data.Get("serial").(string)
 
-	storageEntry, err := req.Storage.Get(ctx, path+"/"+caId+"/"+serial)
+	storageEntry, err := req.Storage.Get(ctx, path+"/"+roleName+"/"+serial)
 	if err != nil {
 		return logical.ErrorResponse("could not read certificate with the serial number: " + serial), err
 	}

--- a/op_issue.go
+++ b/op_issue.go
@@ -71,7 +71,6 @@ func (b *backend) opWriteIssue(ctx context.Context, req *logical.Request, data *
 	if err != nil {
 		return logical.ErrorResponse("Could not get profile configuration for profile " + profileId + ": " + err.Error()), err
 	}
-	b.Logger().Info(fmt.Sprintf("configProfile: %v", configProfile))
 
 	ttl := getTTL(data, configProfile)
 

--- a/op_sign.go
+++ b/op_sign.go
@@ -82,6 +82,9 @@ func (b *backend) opWriteSign(ctx context.Context, req *logical.Request, data *f
 	}
 
 	configProfile, err := getConfigProfile(ctx, req, roleName, profileId)
+	if err != nil {
+		return logical.ErrorResponse("Could not get profile configuration for profile " + profileId + ": " + err.Error()), err
+	}
 
 	ttl := getTTL(data, configProfile)
 
@@ -170,7 +173,7 @@ func (b *backend) opWriteSign(ctx context.Context, req *logical.Request, data *f
 		}
 	}
 
-	storageEntry, err := logical.StorageEntryJSON("sign/"+caId+"/"+respData["serial_number"].(*big.Int).String(), respData)
+	storageEntry, err := logical.StorageEntryJSON("sign/"+roleName+"/"+respData["serial_number"].(*big.Int).String(), respData)
 
 	if err != nil {
 		return logical.ErrorResponse("error creating certificate storage entry"), err


### PR DESCRIPTION
…patible with Kubernetes Cert-Manager

Updated documentation.
Fixed listing and reading stored certs.
Fixed cert storage to be by role config name instead of CA id.
Fix error handling for missing profile in sign operation.